### PR TITLE
Increase scala version to 2.12.10 for compatibility with JDK 13+

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "silectis-scala-assessment"
 organization := "com.silectis"
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.12.7"
+scalaVersion := "2.12.10"
 
 import Dependencies._
 


### PR DESCRIPTION
Resolves a known incompatibility between Scala 2.12.7 and JDK 13+ for projects using macros.

See: https://github.com/scala/bug/issues/11608 and https://github.com/sbt/sbt/issues/5093 for background on the bug.